### PR TITLE
Light settings v1.1.0

### DIFF
--- a/src/AxisUnlocker.KoikatsuSunshine/AxisUnlocker.KoikatsuSunshine.csproj
+++ b/src/AxisUnlocker.KoikatsuSunshine/AxisUnlocker.KoikatsuSunshine.csproj
@@ -24,4 +24,7 @@
   </ItemGroup>
   <Import Project="..\Common.Core\Common.Core.projitems" Label="Shared" />
   <Import Project="..\AxisUnlocker.Core\AxisUnlocker.Core.projitems" Label="Shared" />
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="xcopy $(OutputPath)$(AssemblyName).dll F:\KoikatuSunshine\BepInEx\plugins\MyPlugins\ /y" />
+  </Target>
 </Project>

--- a/src/BetterScaling.KoikatsuSunshine/BetterScaling.KoikatsuSunshine.csproj
+++ b/src/BetterScaling.KoikatsuSunshine/BetterScaling.KoikatsuSunshine.csproj
@@ -22,4 +22,7 @@
   </ItemGroup>
   <Import Project="..\Common.Core\Common.Core.projitems" Label="Shared" />
   <Import Project="..\BetterScaling.Core\BetterScaling.Core.projitems" Label="Shared" />
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="xcopy $(OutputPath)$(AssemblyName).dll F:\KoikatuSunshine\BepInEx\plugins\MyPlugins\ /y" />
+  </Target>
 </Project>

--- a/src/Common.Core/BuildNumber.cs
+++ b/src/Common.Core/BuildNumber.cs
@@ -1,4 +1,4 @@
 ﻿internal static class BuildNumber
 {
-    public const string Version = "5";
+    public const string Version = "6";
 }

--- a/src/ExpressionControl.KoikatsuSunshine/KKS_ExpressionControl.csproj
+++ b/src/ExpressionControl.KoikatsuSunshine/KKS_ExpressionControl.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\BuildSettings.Common.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
 	<OutputPath>..\..\bin\Debug\StarPluginsKKS\</OutputPath>
@@ -24,4 +24,7 @@
   </ItemGroup>
   <Import Project="..\Common.Core\Common.Core.projitems" Label="Shared" />
   <Import Project="..\ExpressionControl.Core\ExpressionControl.Core.projitems" Label="Shared" />
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="xcopy $(OutputPath)$(AssemblyName).dll F:\KoikatuSunshine\BepInEx\plugins\MyPlugins\ /y" />
+  </Target>
 </Project>

--- a/src/LightSettings.Core/HookPatch.cs
+++ b/src/LightSettings.Core/HookPatch.cs
@@ -51,7 +51,7 @@ namespace LightSettings.Koikatu {
                         }
                         UIHandler.SyncGUI(UIHandler.containerLight, _ociLight.light);
                     } else if (_info is OCIItem _ociItem) {
-                        var lights = _ociItem.objectItem.GetComponentsInChildren<Light>(true).ToList();
+                        var lights = LightSettings.GetOwnLights(_ociItem);
                         UIHandler.TogglePanelToggler(lights.Count > 0);
                         if (lights.Count > 0) {
                             UIHandler.SyncGUI(UIHandler.containerItem, lights[0], true);
@@ -90,7 +90,7 @@ namespace LightSettings.Koikatu {
                 if (LightSettings.Instance.IsDebug.Value) LightSettings.logger.LogInfo("Saving data before save...");
                 SceneDataController.itemLightDatas = new System.Collections.Generic.List<LightSaveData>();
                 foreach (OCIItem ociItem in Studio.Studio.Instance.dicObjectCtrl.Values.OfType<OCIItem>()) {
-                    var lights = ociItem.objectItem.GetComponentsInChildren<Light>(true).ToList();
+                    var lights = LightSettings.GetOwnLights(ociItem);
                     if (lights.Count > 0) {
                         if (LightSettings.Instance.IsDebug.Value) LightSettings.logger.LogInfo($"Saving data for {ociItem.treeNodeObject.textName}!");
                         SceneDataController.AddSaveData(SceneDataController.itemLightDatas, KKAPI.Studio.StudioObjectExtensions.GetSceneId(ociItem), lights[0]);
@@ -108,7 +108,7 @@ namespace LightSettings.Koikatu {
                     if (Studio.Studio.Instance.dicObjectCtrl.TryGetValue(data.ObjectId, out ObjectCtrlInfo oci)) {
                         if (oci is OCIItem ociItem) {
                             if (LightSettings.Instance.IsDebug.Value) LightSettings.logger.LogInfo($"Restoring data for {ociItem.treeNodeObject.textName}!");
-                            var lights = ociItem.objectItem.GetComponentsInChildren<Light>(true).ToList();
+                            var lights = LightSettings.GetOwnLights(ociItem);
                             lights[0].enabled = false;
                             SceneDataController.SetLoadedData(data, lights, true, true);
                         }

--- a/src/LightSettings.Core/HookPatch.cs
+++ b/src/LightSettings.Core/HookPatch.cs
@@ -1,6 +1,7 @@
 ﻿using HarmonyLib;
 using UnityEngine;
 using Studio;
+using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Reflection.Emit;
@@ -160,6 +161,23 @@ namespace LightSettings.Koikatu {
                 if (editedIntensity > 2 && _value == 2) return false;
                 editedIntensity = _value;
                 return true;
+            }
+
+            [HarmonyPostfix]
+            [HarmonyWrapSafe]
+            [HarmonyPatch(typeof(AddObjectLight), "Load", new Type[] { typeof(OILightInfo), typeof(ObjectCtrlInfo), typeof(TreeNodeObject), typeof(bool), typeof(int) })]
+            private static void AfterAddObjectLightLoad(OCILight __result) {
+                Light light = __result?.objectLight.GetComponentInChildren<Light>(true);
+                if (light == null) return;
+                LightSettings.SetMaxShadowRes(light);
+            }
+            [HarmonyPostfix]
+            [HarmonyWrapSafe]
+            [HarmonyPatch(typeof(AddObjectItem), "Load", new Type[] { typeof(OIItemInfo), typeof(ObjectCtrlInfo), typeof(TreeNodeObject), typeof(bool), typeof(int) })]
+            private static void AfterAddObjectItemLoad(OCIItem __result) {
+                Light light = __result.objectItem.GetComponentInChildren<Light>(true);
+                if (light == null) return;
+                LightSettings.SetMaxShadowRes(light);
             }
         }
 

--- a/src/LightSettings.Core/HookPatch.cs
+++ b/src/LightSettings.Core/HookPatch.cs
@@ -88,7 +88,7 @@ namespace LightSettings.Koikatu {
             [HarmonyPatch(typeof(Studio.Studio), "SaveScene")]
             internal static bool BeforeStudioSaveScene() {
                 if (LightSettings.Instance.IsDebug.Value) LightSettings.logger.LogInfo("Saving data before save...");
-                SceneDataController.itemLightDatas = new System.Collections.Generic.List<LightSaveData>();
+                SceneDataController.itemLightDatas = new List<LightSaveData>();
                 foreach (OCIItem ociItem in Studio.Studio.Instance.dicObjectCtrl.Values.OfType<OCIItem>()) {
                     var lights = LightSettings.GetOwnLights(ociItem);
                     if (lights.Count > 0) {

--- a/src/LightSettings.Core/LightSaveData.cs
+++ b/src/LightSettings.Core/LightSaveData.cs
@@ -15,7 +15,7 @@ namespace LightSettings.Koikatu {
         public float shadowNormalBias;
         public float shadowNearPlane;
         public LightRenderMode renderMode;
-        public int cullingMask; // 1024 = chara, 2048 = map
+        public int cullingMask; // 1 << 4 = Water, 1 << 10 = Chara, 1 << 11 = Map, 1 << 28 = Gizmo
 
         // Cookie
         public string cookieHash = "";

--- a/src/LightSettings.Core/LightSettings.cs
+++ b/src/LightSettings.Core/LightSettings.cs
@@ -143,7 +143,7 @@ namespace LightSettings.Koikatu {
             var lights = new List<Light>();
 
             if (lightToModify == null) {
-                GetCurrentLights(_type, _value, out isChaLight);
+                lights = GetCurrentLights(_type, _value, out isChaLight);
             } else {
                 lights.Add(lightToModify);
                 isChaLight = lightToModify == Singleton<Studio.Studio>.Instance.gameObject.GetComponentInChildren<Light>(true);
@@ -396,7 +396,7 @@ namespace LightSettings.Koikatu {
 
         internal static List<Light> GetOwnLights(OCIItem ociItem) {
             var allLights = ociItem.objectItem.GetComponentsInChildren<Light>(true).ToList();
-            Log.Warning($"Item '{ociItem.treeNodeObject.textName}' Light count: " + allLights.Count);
+            if (Instance.IsDebug.Value) Log.Info($"Item '{ociItem.treeNodeObject.textName}' Light count: " + allLights.Count);
             if (allLights.Count == 0) return allLights;
             var children = new List<TreeNodeObject>(ociItem.treeNodeObject.child);
             TreeNodeObject child;
@@ -405,7 +405,7 @@ namespace LightSettings.Koikatu {
                 if (Studio.Studio.Instance.dicInfo.TryGetValue(child, out var ociChild)) {
                     if (ociChild is OCILight childLight) {
                         var childLights = childLight.objectLight.GetComponentsInChildren<Light>(true).ToList();
-                        Log.Warning($"Child lights '{childLight.treeNodeObject.textName}' count: " + childLights.Count);
+                        if (Instance.IsDebug.Value) Log.Info($"Child lights '{childLight.treeNodeObject.textName}' count: " + childLights.Count);
                         foreach (var light in childLights) {
                             allLights.Remove(light);
                         }

--- a/src/LightSettings.Core/LightSettings.cs
+++ b/src/LightSettings.Core/LightSettings.cs
@@ -176,12 +176,10 @@ namespace LightSettings.Koikatu {
                         break;
                     case SettingType.CullingMask:
                         if (_value is int maskVal) {
+                            if (Instance.IsDebug.Value) logger.LogInfo($"Light culling mask set to {light.cullingMask}");
                             if ((light.cullingMask & maskVal) == 0) light.cullingMask |= maskVal;
                             else light.cullingMask &= ~maskVal;
-                            // Make sure character light illuminates the gizmos
-                            if (isChaLight) light.cullingMask |= 1 << 28;
                             if (isChaLight) SceneDataController.charaLightData.cullingMask = light.cullingMask;
-                            if (Instance.IsDebug.Value) logger.LogInfo($"Light culling mask set to {light.cullingMask}");
                         }
                         break;
                     case SettingType.CookieSize:

--- a/src/LightSettings.Core/SceneDataController.cs
+++ b/src/LightSettings.Core/SceneDataController.cs
@@ -61,13 +61,21 @@ namespace LightSettings.Koikatu {
 
             if (LightSettings.charaLightSetCountDown <= 0) {
                 if (LightSettings.Instance.IsDebug.Value) LightSettings.logger.LogInfo("Chara light data not found, copying existing settings!");
+
+                // Apply max shadow resolution
+                int shadowCustomResolution = charaLight.shadowCustomResolution;
+                if (shadowCustomResolution == -1 && LightSettings.Instance.MaxShadowResDirectional.Value > -1) {
+                    shadowCustomResolution = LightSettings.Instance.MaxShadowResDirectional.Value;
+                    charaLight.shadowCustomResolution = shadowCustomResolution;
+                }
+
                 charaLightData = new LightSaveData {
                     ObjectId = chaLightID,
 
                     state = charaLight.enabled,
                     shadows = charaLight.shadows,
                     shadowResolution = charaLight.shadowResolution,
-                    shadowCustomResolution = charaLight.shadowCustomResolution,
+                    shadowCustomResolution = shadowCustomResolution,
                     shadowStrength = charaLight.shadowStrength,
                     shadowBias = charaLight.shadowBias,
                     shadowNormalBias = charaLight.shadowNormalBias,

--- a/src/LightSettings.Core/SceneDataController.cs
+++ b/src/LightSettings.Core/SceneDataController.cs
@@ -45,9 +45,11 @@ namespace LightSettings.Koikatu {
                                 SetLoadedData(lightData, ociItem.objectItem.GetComponentsInChildren<Light>(true).ToList(), true, true);
                             }
                         } else if (lightData.ObjectId == chaLightID) {
-                            charaLightData = lightData;
-                            UIHandler.chaLightToggle.GetComponentInChildren<UnityEngine.UI.Toggle>(true).isOn = charaLightData.state;
-                            LightSettings.charaLightSetCountDown = 5;
+                            if (operation == SceneOperationKind.Load) {
+                                charaLightData = lightData;
+                                UIHandler.chaLightToggle.GetComponentInChildren<UnityEngine.UI.Toggle>(true).isOn = charaLightData.state;
+                                LightSettings.charaLightSetCountDown = 5;
+                            }
                         } else if (lightData.ObjectId == mapLightID) {
                             var map = Singleton<Map>.Instance.mapRoot;
                             if (map) {

--- a/src/LightSettings.Core/SceneDataController.cs
+++ b/src/LightSettings.Core/SceneDataController.cs
@@ -1,4 +1,5 @@
 ﻿using ExtensibleSaveFormat;
+using Illusion.Extensions;
 using KKAPI.Studio.SaveLoad;
 using KKAPI.Utilities;
 using MessagePack;
@@ -42,7 +43,7 @@ namespace LightSettings.Koikatu {
                             if (oci is OCILight ociLight) {
                                 SetLoadedData(lightData, new List<Light> { ociLight.light });
                             } else if (oci is OCIItem ociItem) {
-                                SetLoadedData(lightData, ociItem.objectItem.GetComponentsInChildren<Light>(true).ToList(), true, true);
+                                SetLoadedData(lightData, LightSettings.GetOwnLights(ociItem), true, true);
                             }
                         } else if (lightData.ObjectId == chaLightID) {
                             if (operation == SceneOperationKind.Load) {

--- a/src/LightSettings.Core/SceneDataController.cs
+++ b/src/LightSettings.Core/SceneDataController.cs
@@ -145,6 +145,18 @@ namespace LightSettings.Koikatu {
                 if (setState) {
                     light.enabled = lightData.state;
                 }
+
+                // Cookie
+                // Unity bug: Cookie must be set first, otherwise negative values in other settings will be clamped to 0
+                if (LightSettings.cookieDict.TryGetValue(lightData.cookieHash, out byte[] data)) {
+                    light.cookie = LightSettings.LightCookieFromBytes(data, light);
+                    light.cookieSize = lightData.cookieSize;
+                } else {
+                    light.cookie = null;
+                    light.cookieSize = 0;
+                }
+
+                // Other settings
                 light.shadows = lightData.shadows;
                 light.shadowResolution = lightData.shadowResolution;
                 light.shadowCustomResolution = lightData.shadowCustomResolution;
@@ -154,15 +166,6 @@ namespace LightSettings.Koikatu {
                 light.shadowNearPlane = lightData.shadowNearPlane;
                 light.renderMode = lightData.renderMode;
                 light.cullingMask = lightData.cullingMask;
-
-                // Cookie
-                if (LightSettings.cookieDict.TryGetValue(lightData.cookieHash, out byte[] data)) {
-                    light.cookie = LightSettings.LightCookieFromBytes(data, light);
-                    light.cookieSize = lightData.cookieSize;
-                } else {
-                    light.cookie = null;
-                    light.cookieSize = 0;
-                }
 
                 // Exclusive to lights attached to items
                 if (setExtra) {

--- a/src/LightSettings.Core/UIHandler.cs
+++ b/src/LightSettings.Core/UIHandler.cs
@@ -201,7 +201,7 @@ namespace LightSettings.Koikatu {
             var spr = Sprite.Create(bg, new Rect(0, 0, bg.width, bg.height), old.pivot, old.pixelsPerUnit, 0, SpriteMeshType.FullRect, new Vector4(4,4,4,4));
             newBg.GetComponent<Image>().sprite = spr;
             newBg.GetComponent<Image>().type = Image.Type.Sliced;
-            newBg.GetComponent<RectTransform>().sizeDelta = new Vector2(190, 433);
+            newBg.GetComponent<RectTransform>().sizeDelta = new Vector2(190, 438);
             newBg.name = "Background";
 
             // Create type / resolution dropdown controls
@@ -253,12 +253,14 @@ namespace LightSettings.Koikatu {
             cullMask.localScale = Vector3.one;
             cullMask.localPosition = new Vector2(0, -545);
             MakeLabel(cullMask, "Culling Mask", Vector2.zero);
-            UnityAction<bool> charaToggleCallback = (x) => LightSettings.SetLightSetting(LightSettings.SettingType.CullingMask, 1<<10);
+            UnityAction<bool> charaToggleCallback = (x) => LightSettings.SetLightSetting(LightSettings.SettingType.CullingMask, 1 << 10);
             MakeToggle(cullMask, "Chara", new Vector2(10f, -20f), new Vector2(60f, 0), charaToggleCallback);
-            UnityAction<bool> mapToggleCallback = (x) => LightSettings.SetLightSetting(LightSettings.SettingType.CullingMask, 1<<11);
+            UnityAction<bool> mapToggleCallback = (x) => LightSettings.SetLightSetting(LightSettings.SettingType.CullingMask, 1 << 11);
             MakeToggle(cullMask, "Map", new Vector2(100f, -20f), new Vector2(60f, 0), mapToggleCallback);
             UnityAction<bool> waterToggleCallback = (x) => LightSettings.SetLightSetting(LightSettings.SettingType.CullingMask, 1 << 4);
-            MakeToggle(cullMask, "Water", new Vector2(10f, -40f), new Vector2(60f, 0), waterToggleCallback);
+            MakeToggle(cullMask, "Water", new Vector2(10f, -45f), new Vector2(60f, 0), waterToggleCallback);
+            UnityAction<bool> gizmoToggleCallback = (x) => LightSettings.SetLightSetting(LightSettings.SettingType.CullingMask, 1 << 28);
+            MakeToggle(cullMask, "Gizmos", new Vector2(100f, -45f), new Vector2(60f, 0), gizmoToggleCallback);
 
             // Create cookie interface
             CreateCookie(container, new Vector2(190, -180));
@@ -372,10 +374,11 @@ namespace LightSettings.Koikatu {
 
             // Culling Mask
             if (LightSettings.Instance.IsDebug.Value) LightSettings.logger.LogInfo("Syncing culling mask...");
-            if (_light.cullingMask == -1) _light.cullingMask = (1 << 4) | (1 << 10) | (1 << 11) + 23;
+            if (_light.cullingMask == -1) _light.cullingMask = (1 << 4) | (1 << 10) | (1 << 11) | (1 << 28) + 23;
             container.Find("Culling Mask").GetChild(1).GetComponentInChildren<Toggle>(true).isOn = (_light.cullingMask & (1 << 10)) != 0;
             container.Find("Culling Mask").GetChild(2).GetComponentInChildren<Toggle>(true).isOn = (_light.cullingMask & (1 << 11)) != 0;
             container.Find("Culling Mask").GetChild(3).GetComponentInChildren<Toggle>(true).isOn = (_light.cullingMask & (1 << 4)) != 0;
+            container.Find("Culling Mask").GetChild(4).GetComponentInChildren<Toggle>(true).isOn = (_light.cullingMask & (1 << 28)) != 0;
 
             // State / Color / Intensity / Range / Angle
             if (syncExtra) {

--- a/src/LightSettings.KoikatsuSunshine/LightSettings.KoikatsuSunshine.csproj
+++ b/src/LightSettings.KoikatsuSunshine/LightSettings.KoikatsuSunshine.csproj
@@ -29,4 +29,7 @@
   </ItemGroup>
   <Import Project="..\Common.Core\Common.Core.projitems" Label="Shared" />
   <Import Project="..\LightSettings.Core\LightSettings.Core.projitems" Label="Shared" />
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="xcopy $(OutputPath)$(AssemblyName).dll F:\KoikatuSunshine\BepInEx\plugins\MyPlugins\ /y" />
+  </Target>
 </Project>

--- a/src/LightToggler.KoikatuSunshine/LightToggler.KoikatuSunshine.csproj
+++ b/src/LightToggler.KoikatuSunshine/LightToggler.KoikatuSunshine.csproj
@@ -22,4 +22,7 @@
   </ItemGroup>
   <Import Project="..\Common.Core\Common.Core.projitems" Label="Shared" />
   <Import Project="..\LightToggler.Core\LightToggler.Core.projitems" Label="Shared" />
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="xcopy $(OutputPath)$(AssemblyName).dll F:\KoikatuSunshine\BepInEx\plugins\MyPlugins\ /y" />
+  </Target>
 </Project>

--- a/src/MassShaderEditor.KoikatsuSunshine/MassShaderEditor.KoikatsuSunshine.csproj
+++ b/src/MassShaderEditor.KoikatsuSunshine/MassShaderEditor.KoikatsuSunshine.csproj
@@ -36,4 +36,7 @@
   </ItemGroup>
   <Import Project="..\Common.Core\Common.Core.projitems" Label="Shared" />
   <Import Project="..\MassShaderEditor.Core\MassShaderEditor.Core.projitems" Label="Shared" />
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="xcopy $(OutputPath)$(AssemblyName).dll F:\KoikatuSunshine\BepInEx\plugins\MyPlugins\ /y" />
+  </Target>
 </Project>


### PR DESCRIPTION
- fix negative values having one fewer digits of precision
- fix negative shadow bias being clamped to 0 [Acezen]
- Add Water [Laeknir] / Gizmo layer toggles
- Don't overwrite chara light settings on "Import"
- Add default max res settings for lights that are loaded as autores
- Fix erroneously modifying Lights parented to items